### PR TITLE
.github: upgrade actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref }}
           # Allows to fetch all history for all branches and tags. Need this for proper versioning.


### PR DESCRIPTION
Fetch fresh version of some GH actions to avoid deprecated Node.js warnings.